### PR TITLE
import hueys_setting config if not present

### DIFF
--- a/django_huey/apps.py
+++ b/django_huey/apps.py
@@ -12,7 +12,11 @@ class DjangoHueyConfig(AppConfig):
             monitor_installed = False
 
         if monitor_installed:
-            from django_huey.config import config
+
+            from django_huey import config
+            if not hasattr(config, 'hueys_setting'):
+                from django_huey.config import config
+
             from django_huey import signal, on_startup
 
             for queuename in config.hueys_setting.keys():


### PR DESCRIPTION
Problem: Error importing config when monitor is installed

Versions:

 - django==4.2
 - django-huey==1.2.0
 - django-huey-monitor==0.8.1

Error:

```
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/Users/dnuske/.pyenv/versions/3.11.8/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/Users/dnuske/.pyenv/versions/3.11.8/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
    autoreload.raise_last_exception()
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 394, in execute
    autoreload.check_errors(django.setup)()
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
  File "/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django_huey/apps.py", line 18, in ready
    from django_huey.config import config
ImportError: cannot import name 'config' from 'django_huey.config' (/Users/dnuske/code/neolicense/bake/venv/lib/python3.11/site-packages/django_huey/config.py)
```

fix: if config is not present on import, try importing it again from a different path where it may be present. (And it actually is for the versions that we are using)