### PR TITLE
Assign `queue_name` before it is used

### DIFF
--- a/django_huey/management/commands/djangohuey.py
+++ b/django_huey/management/commands/djangohuey.py
@@ -70,9 +70,9 @@ class Command(BaseCommand):
             except RuntimeError:
                 pass
 
-        queue_name = options.get("queue")
+        # use the provided name or the default queue
+        queue_name = get_queue_name(options.get("queue") or None)
         queue = get_queue(queue_name)
-        queue_name = get_queue_name(queue_name)
 
         consumer_options = {}
         consumer_options.update(self.default_queue_settings(queue_name))


### PR DESCRIPTION
After reading this command, it wasn't clear what was happening.

Hopefully, this is the same result with more understandable ordering.