### PR TITLE
Fix for Python 3.14, using fork instead of forkserver

### DIFF
--- a/django_huey/management/commands/djangohuey.py
+++ b/django_huey/management/commands/djangohuey.py
@@ -59,7 +59,8 @@ class Command(BaseCommand):
 
         # Python 3.8+ on MacOS uses an incompatible multiprocess model. In this
         # case we must explicitly configure mp to use fork().
-        if sys.version_info >= (3, 8) and sys.platform == "darwin":
+        if ((sys.version_info >= (3, 8) and sys.platform == 'darwin') or
+            (sys.version_info >= (3, 14))):
             # Apparently this was causing a "context has already been set"
             # error for some user. We'll just pass and hope for the best.
             # They're apple users so presumably nothing important will be lost.


### PR DESCRIPTION
Fixes #35.  See also [1], [2].

[1] https://github.com/coleifer/huey/commit/bd2f795db112f8251db004d56987a0df5f9140f9
[2] https://github.com/coleifer/huey/issues/867